### PR TITLE
feature: use commonmarker gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,3 +27,6 @@ end
 # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
 gem "listen", ">= 3.5.1"
 # gem "avo", ">= 3.2.1"
+
+gem "commonmarker"
+gem "redcarpet"

--- a/Gemfile
+++ b/Gemfile
@@ -30,3 +30,5 @@ gem "listen", ">= 3.5.1"
 
 gem "commonmarker"
 gem "redcarpet"
+
+gem "minitest-difftastic", "~> 0.2.1", :group => :test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,16 @@ GEM
     connection_pool (2.5.0)
     crass (1.0.6)
     date (3.4.1)
+    difftastic (0.6.0)
+      pretty_please
+    difftastic (0.6.0-arm64-darwin)
+      pretty_please
+    difftastic (0.6.0-x86_64-darwin)
+      pretty_please
+    difftastic (0.6.0-x86_64-linux)
+      pretty_please
+    dispersion (0.2.0)
+      prism
     drb (2.2.1)
     dry-cli (1.2.0)
     erubi (1.13.1)
@@ -131,6 +141,8 @@ GEM
     marcel (1.0.4)
     mini_mime (1.1.5)
     minitest (5.25.4)
+    minitest-difftastic (0.2.1)
+      difftastic (~> 0.6)
     mutex_m (0.3.0)
     net-imap (0.5.5)
       date
@@ -164,7 +176,10 @@ GEM
       racc
     pp (0.6.2)
       prettyprint
+    pretty_please (0.2.0)
+      dispersion (~> 0.2)
     prettyprint (0.2.0)
+    prism (1.3.0)
     propshaft (1.1.0)
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)
@@ -316,6 +331,7 @@ DEPENDENCIES
   commonmarker
   listen (>= 3.5.1)
   marksmith!
+  minitest-difftastic (~> 0.2.1)
   propshaft
   puma
   rails (>= 7.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     marksmith (0.1.2)
       activesupport
-      redcarpet
 
 GEM
   remote: https://rubygems.org/
@@ -85,6 +84,12 @@ GEM
     bigdecimal (3.1.9)
     bindex (0.8.1)
     builder (3.3.0)
+    commonmarker (2.0.4)
+      rb_sys (~> 0.9)
+    commonmarker (2.0.4-aarch64-linux)
+    commonmarker (2.0.4-arm64-darwin)
+    commonmarker (2.0.4-x86_64-darwin)
+    commonmarker (2.0.4-x86_64-linux)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
     crass (1.0.6)
@@ -212,9 +217,12 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.2.1)
+    rake-compiler-dock (1.9.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
+    rb_sys (0.9.110)
+      rake-compiler-dock (= 1.9.1)
     rdoc (6.12.0)
       psych (>= 4.0.0)
     redcarpet (3.6.0)
@@ -305,11 +313,13 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  commonmarker
   listen (>= 3.5.1)
   marksmith!
   propshaft
   puma
   rails (>= 7.0.0)
+  redcarpet
   rubocop-rails-omakase
   sqlite3
   stimulus-rails

--- a/README.md
+++ b/README.md
@@ -172,14 +172,23 @@ In your `show.html.erb` view or the place where you want to render the compiled 
 > sanitize(body, tags: %w(table th tr td span) + ActionView::Helpers::SanitizeHelper.sanitizer_vendor.safe_list_sanitizer.allowed_tags.to_a)
 > ```
 
-### Customize the renderer
+## Customize the renderer
 
-You can customize the renderer by overriding the `Marksmith::Renderer` model.
+Marksmith comes with a default renderer that uses `Commonmarker` by default but it can be changed to `Redcarpet` in the configuration.
+
+```ruby
+# config/initializers/marksmith.rb
+Marksmith.configure do |config|
+  config.parser = "redcarpet"
+end
+```
+
+### Add your own renderer
+
+You can completely customize the renderer by overriding the `Marksmith::Renderer` model.
 
 ```ruby
 # app/models/marksmith/renderer.rb
-require "redcarpet"
-
 module Marksmith
   class Renderer
     def initialize(body:)

--- a/README.md
+++ b/README.md
@@ -154,8 +154,8 @@ end
 
 ## Built-in preview renderer
 
-The renderer is powered by [`Redcarpet`](https://github.com/vmg/redcarpet).
-It supports basic styles for headings, `strong`, `italic` and others.
+The renderer is powered by [`Commonmarker`](https://github.com/gjtorikian/commonmarker) by default but it can be changed to [`Redcarpet`](https://github.com/vmg/redcarpet) in the configuration or add your own logic by customizing the `Marksmith::Renderer` model.
+It supports basic styles like headings, `strong`, `italic` and others.
 
 In your `show.html.erb` view or the place where you want to render the compiled markup use the `marksmithed` helper and it will run the content through the renderer.
 

--- a/README.md
+++ b/README.md
@@ -182,21 +182,12 @@ require "redcarpet"
 
 module Marksmith
   class Renderer
-    def renderer
-      ::Redcarpet::Markdown.new(
-        ::Redcarpet::Render::HTML,
-        tables: true,
-        lax_spacing: true,
-        fenced_code_blocks: true,
-        space_after_headers: true,
-        hard_wrap: true,
-        autolink: true,
-        strikethrough: true,
-        underline: true,
-        highlight: true,
-        quote: true,
-        with_toc_data: true
-      )
+    def initialize(body:)
+      @body = body
+    end
+
+    def render
+      # Your custom renderer logic here
     end
   end
 end

--- a/app/components/marksmith/markdown_field/show_component.html.erb
+++ b/app/components/marksmith/markdown_field/show_component.html.erb
@@ -1,3 +1,3 @@
 <%= field_wrapper **field_wrapper_args, full_width: true do %>
-  <%= render partial: "marksmith/shared/rendered_body", locals: { body: Marksmith::Renderer.new.renderer.render(@field.value) } %>
+  <%= render partial: "marksmith/shared/rendered_body", locals: { body: Marksmith::Renderer.new(body: @field.value).render } %>
 <% end %>

--- a/app/controllers/marksmith/markdown_previews_controller.rb
+++ b/app/controllers/marksmith/markdown_previews_controller.rb
@@ -1,7 +1,7 @@
 module Marksmith
   class MarkdownPreviewsController < ApplicationController
     def create
-      @body = Marksmith::Renderer.new.renderer.render(params[:body])
+      @body = Marksmith::Renderer.new(body: params[:body]).render
     end
   end
 end

--- a/app/models/marksmith/renderer.rb
+++ b/app/models/marksmith/renderer.rb
@@ -13,7 +13,9 @@ module Marksmith
     end
 
     def render_commonmarker
-      Commonmarker.to_html(@body)
+      # commonmarker expects an utf-8 encoded string
+      body = @body.to_s.dup.force_encoding('utf-8')
+      Commonmarker.to_html(body)
     end
 
     def render_redcarpet
@@ -30,7 +32,7 @@ module Marksmith
         highlight: true,
         quote: true,
         with_toc_data: true
-      )
+      ).render(@body)
     end
   end
 end

--- a/app/models/marksmith/renderer.rb
+++ b/app/models/marksmith/renderer.rb
@@ -1,8 +1,22 @@
-require "redcarpet"
-
 module Marksmith
   class Renderer
-    def renderer
+    def initialize(body:)
+      @body = body
+    end
+
+    def render
+      if Marksmith.configuration.parser == "commonmarker"
+        render_commonmarker
+      else
+        render_redcarpet
+      end
+    end
+
+    def render_commonmarker
+      Commonmarker.to_html(@body)
+    end
+
+    def render_redcarpet
       ::Redcarpet::Markdown.new(
         ::Redcarpet::Render::HTML,
         tables: true,

--- a/lib/marksmith/configuration.rb
+++ b/lib/marksmith/configuration.rb
@@ -4,6 +4,7 @@ module Marksmith
 
     config_accessor(:automatically_mount_engine) { true }
     config_accessor(:mount_path) { "/marksmith" }
+    config_accessor(:parser) { "commonmarker" }
   end
 
   def self.configuration

--- a/lib/marksmith/helper.rb
+++ b/lib/marksmith/helper.rb
@@ -1,7 +1,7 @@
 module Marksmith
   module Helper
     def marksmithed(body)
-      Marksmith::Renderer.new.renderer.render(body)
+      Marksmith::Renderer.new(body:).render
     end
 
     def marksmith_tag(name, **kwargs, &block)

--- a/marksmith.gemspec
+++ b/marksmith.gemspec
@@ -19,5 +19,4 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency "activesupport"
-  spec.add_dependency "redcarpet"
 end

--- a/test/dummy/config/initializers/marksmith.rb
+++ b/test/dummy/config/initializers/marksmith.rb
@@ -1,4 +1,5 @@
 # Marksmith.configure do |config|
 #   config.automatically_mount_engine = true
 #   config.mount_path = "/marksmith"
+#   config.parser = "redcarpet"
 # end

--- a/test/dummy/config/initializers/marksmith.rb
+++ b/test/dummy/config/initializers/marksmith.rb
@@ -1,5 +1,5 @@
 # Marksmith.configure do |config|
 #   config.automatically_mount_engine = true
 #   config.mount_path = "/marksmith"
-#   config.parser = "redcarpet"
+#   config.parser = "commonmarker"
 # end

--- a/test/lib/marksmith/commonmarker_helper_test.rb
+++ b/test/lib/marksmith/commonmarker_helper_test.rb
@@ -1,0 +1,137 @@
+require "test_helper"
+require "marksmith/helper"
+
+class CommonmarkerHelperTest < ActiveSupport::TestCase
+  include Marksmith::Helper
+
+  def setup
+    Marksmith.configuration.parser = "commonmarker"
+  end
+
+  test "marksmithed#renders simple markdown" do
+    body = "# Hello World\n\nThis is a test."
+    expected = "<h1><a href=\"#hello-world\" aria-hidden=\"true\" class=\"anchor\" id=\"hello-world\"></a>Hello World</h1>\n<p>This is a test.</p>\n"
+
+    assert_equal expected, marksmithed(body)
+  end
+
+  test "marksmithed#when rendering a header" do
+    body = "# Header"
+    expected = "<h1><a href=\"#header\" aria-hidden=\"true\" class=\"anchor\" id=\"header\"></a>Header</h1>\n"
+
+    assert_equal expected, marksmithed(body)
+  end
+
+  # Test rendering a list
+  test "marksmithed#when rendering a list" do
+    body = "- item1\n- item2"
+    expected = "<ul>\n<li>item1</li>\n<li>item2</li>\n</ul>\n"
+
+    assert_equal expected, marksmithed(body)
+  end
+
+  # Test rendering a code block
+  test "marksmithed#when rendering a code block" do
+    body = "```\ndef hello\n  puts 'hello'\nend\n```"
+    expected = "<pre style=\"background-color:#2b303b;\"><code><span style=\"color:#c0c5ce;\">def hello\n</span><span style=\"color:#c0c5ce;\">  puts &#39;hello&#39;\n</span><span style=\"color:#c0c5ce;\">end\n</span></code></pre>\n"
+
+    assert_equal expected, marksmithed(body)
+  end
+
+  # Test rendering a table
+  test "marksmithed#when rendering a table" do
+    body = "| a | b |\n|---|---|\n| c | d |"
+    expected = "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>c</td>\n<td>d</td>\n</tr>\n</tbody>\n</table>\n"
+
+    assert_equal expected, marksmithed(body)
+  end
+
+  # Test rendering strikethrough text
+  test "marksmithed#when rendering strikethrough text" do
+    body = "This is ~~strikethrough~~ text."
+    expected = "<p>This is <del>strikethrough</del> text.</p>\n"
+
+    assert_equal expected, marksmithed(body)
+  end
+
+  # Test rendering underline text using single underscores (emphasis)
+  test "marksmithed#when rendering underline (emphasis) text" do
+    body = "This is _underline_ text."
+    expected = "<p>This is <em>underline</em> text.</p>\n"
+
+    assert_equal expected, marksmithed(body)
+  end
+
+  # Test rendering underline text using double underscores (underline)
+  test "marksmithed#when rendering strong text using double underscores" do
+    body = "This is __underline__ text."
+    expected = "<p>This is <strong>underline</strong> text.</p>\n"
+
+    assert_equal expected, marksmithed(body)
+  end
+
+  # Test rendering a blockquote
+  test "marksmithed#when rendering a blockquote" do
+    body = "> This is a blockquote."
+    expected = "<blockquote>\n<p>This is a blockquote.</p>\n</blockquote>\n"
+
+    assert_equal expected, marksmithed(body)
+  end
+
+  # Test rendering autolinks
+  test "marksmithed#when rendering autolinks" do
+    body = "Visit https://example.com"
+    expected = "<p>Visit <a href=\"https://example.com\">https://example.com</a></p>\n"
+
+    assert_equal expected, marksmithed(body)
+  end
+
+  # Test rendering fenced code blocks with language specification
+  test "marksmithed#when rendering fenced code blocks with language" do
+    body = "```ruby\ndef hello\n  puts 'hello'\nend\n```"
+    expected = "<pre lang=\"ruby\" style=\"background-color:#2b303b;\"><code><span style=\"color:#b48ead;\">def </span><span style=\"color:#8fa1b3;\">hello\n</span><span style=\"color:#c0c5ce;\">  </span><span style=\"color:#96b5b4;\">puts </span><span style=\"color:#c0c5ce;\">&#39;</span><span style=\"color:#a3be8c;\">hello</span><span style=\"color:#c0c5ce;\">&#39;\n</span><span style=\"color:#b48ead;\">end\n</span></code></pre>\n"
+
+    assert_equal expected, marksmithed(body)
+  end
+
+  # Test rendering hard line breaks
+  test "marksmithed#when rendering with hard line breaks" do
+    body = "Line1\nLine2"
+    expected = "<p>Line1<br />\nLine2</p>\n"
+
+    assert_equal expected, marksmithed(body)
+  end
+
+  # Test rendering with lax spacing (multiple paragraphs without explicit breaks)
+  test "marksmithed#when rendering with lax spacing" do
+    body = "Paragraph one
+Paragraph two"
+    expected = "<p>Paragraph one<br />\nParagraph two</p>\n"
+
+    assert_equal expected, marksmithed(body)
+  end
+
+  # Test rendering emphasis and strong emphasis
+  test "marksmithed#when rendering emphasis and strong emphasis" do
+    body = "This is *emphasized* and this is **strongly emphasized**."
+    expected = "<p>This is <em>emphasized</em> and this is <strong>strongly emphasized</strong>.</p>\n"
+
+    assert_equal expected, marksmithed(body)
+  end
+
+  # Test rendering an empty string
+  test "marksmithed#when rendering an empty string" do
+    body = ""
+    expected = ""
+
+    assert_equal expected, marksmithed(body)
+  end
+
+  # Test handling of nil input
+  test "marksmithed#when handling nil input" do
+    body = nil
+    expected = ""
+
+    assert_equal expected, marksmithed(body.to_s)
+  end
+end

--- a/test/lib/marksmith/redcarpet_helper_test.rb
+++ b/test/lib/marksmith/redcarpet_helper_test.rb
@@ -1,8 +1,12 @@
 require "test_helper"
 require "marksmith/helper"
 
-class HelperTest < ActiveSupport::TestCase
+class RedcarpetHelperTest < ActiveSupport::TestCase
   include Marksmith::Helper
+
+  def setup
+    Marksmith.configuration.parser = "redcarpet"
+  end
 
   test "marksmithed#renders simple markdown" do
     body = "# Hello World\n\nThis is a test."


### PR DESCRIPTION
Fixes #19 

This PR adds the ability to use the [`commonmarker`](https://github.com/gjtorikian/commonmarker) gem.
It's an optional dependency as we'd like to allow users to choose which renderer they use.

### Breaking changes

1. The gem doesn't ship with a parser so you must manually add it.

```ruby
# add marksmith
gem "marksmith"

# add a markdown parser
gem "commonmarker"
# or
gem "redcarpet"
```

2. The rendered changed it's API

```ruby
# before
Marksmith::Renderer.new.renderer.render("**hi**")

# after
Marksmith::Renderer.new(body: "**hi**").render
```

