### PR TITLE
fix: urlencode filenames

### DIFF
--- a/app/frontend/entrypoints/javascript/controllers/marksmith_controller.js
+++ b/app/frontend/entrypoints/javascript/controllers/marksmith_controller.js
@@ -139,7 +139,7 @@ export default class extends Controller {
   }
 
   #pathFromBlob(blob) {
-    return `/rails/active_storage/blobs/redirect/${blob.signed_id}/${blob.filename}`
+    return `/rails/active_storage/blobs/redirect/${blob.signed_id}/${encodeURIComponent(blob.filename)}`
   }
 
   #markdownLinkFromUrl(filename, url, contentType) {


### PR DESCRIPTION
Empty spaces in filenames breaks commonmarker's image parsing.