### PR TITLE
chore: remove tailwind from mandatory deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "@rails/activestorage": "^8.0.100",
     "@rails/request.js": "^0.0.11",
     "@rollup/plugin-node-resolve": "^16.0.0",
+    "@tailwindcss/cli": "^4.0.0",
+    "@tailwindcss/typography": "^0.5.16",
     "@tailwindcss/vite": "^4.0.0",
     "lodash": "^4.17.21",
     "rollup": "^4.31.0",
@@ -44,9 +46,5 @@
     "build": "yarn build:js && yarn build:css",
     "build:js": "rollup -c",
     "build:css": "npx @tailwindcss/cli -i app/frontend/entrypoints/application.css -o app/assets/stylesheets/marksmith.css"
-  },
-  "dependencies": {
-    "@tailwindcss/cli": "^4.0.0",
-    "@tailwindcss/typography": "^0.5.16"
   }
 }


### PR DESCRIPTION
These tailwind dependencies should not be transitive. they are used only in development.