### PR TITLE
Respect media and file upload config flags in Markdown field + minor URL encoding fix

### DIFF
--- a/app/components/marksmith/markdown_field/edit_component.html.erb
+++ b/app/components/marksmith/markdown_field/edit_component.html.erb
@@ -1,7 +1,7 @@
 <%= field_wrapper **field_wrapper_args, full_width: true do %>
   <%= @form.marksmith @field.id,
     gallery: {
-      enabled: Avo::MediaLibrary.configuration.enabled,
+      enabled: @field.gallery_enabled?,
       open_path: avo.attach_media_path,
       turbo_frame: ::Avo::MODAL_FRAME_ID,
       params: {
@@ -16,7 +16,7 @@
     },
     extra_preview_params: {
       resource_class: @resource.class.name,
-      field_id: field.id,
+      field_id: @field.id,
     }
   %>
 <% end %>

--- a/app/components/marksmith/markdown_field/edit_component.html.erb
+++ b/app/components/marksmith/markdown_field/edit_component.html.erb
@@ -18,6 +18,7 @@
       resource_class: @resource.class.name,
       field_id: @field.id,
       **@field.extra_preview_params
-    }
+    },
+    enable_file_uploads: @field.file_uploads
   %>
 <% end %>

--- a/app/components/marksmith/markdown_field/edit_component.html.erb
+++ b/app/components/marksmith/markdown_field/edit_component.html.erb
@@ -17,6 +17,7 @@
     extra_preview_params: {
       resource_class: @resource.class.name,
       field_id: @field.id,
+      **@field.extra_preview_params
     }
   %>
 <% end %>

--- a/app/components/marksmith/markdown_field/edit_component.html.erb
+++ b/app/components/marksmith/markdown_field/edit_component.html.erb
@@ -7,7 +7,7 @@
       params: {
         resource_name: @resource.singular_route_key,
         controller_name: "marksmith",
-        controller_selector: "[data-unique-selector='#{unique_id}']",
+        controller_selector: "[data-unique-selector=#{unique_id}]",
         record_id: @resource&.record&.to_param,
       }
     },

--- a/app/components/marksmith/markdown_field/edit_component.html.erb
+++ b/app/components/marksmith/markdown_field/edit_component.html.erb
@@ -1,7 +1,7 @@
 <%= field_wrapper **field_wrapper_args, full_width: true do %>
   <%= @form.marksmith @field.id,
     gallery: {
-      enabled: true,
+      enabled: Avo::MediaLibrary.configuration.enabled,
       open_path: avo.attach_media_path,
       turbo_frame: ::Avo::MODAL_FRAME_ID,
       params: {

--- a/lib/marksmith/fields/markdown_field.rb
+++ b/lib/marksmith/fields/markdown_field.rb
@@ -1,11 +1,13 @@
 module Marksmith
   module Fields
     class MarkdownField < Avo::Fields::BaseField
-      attr_reader :extra_preview_params
+      attr_reader :extra_preview_params,
+        :file_uploads
 
       def initialize(id, **args, &block)
         @media_library = args[:media_library].nil? ? true : args[:media_library]
         @extra_preview_params = args[:extra_preview_params] || {}
+        @file_uploads = args[:file_uploads]
 
         super(id, **args, &block)
 

--- a/lib/marksmith/fields/markdown_field.rb
+++ b/lib/marksmith/fields/markdown_field.rb
@@ -2,6 +2,8 @@ module Marksmith
   module Fields
     class MarkdownField < Avo::Fields::BaseField
       def initialize(id, **args, &block)
+        @media_library = args[:media_library].nil? ? true : args[:media_library]
+
         super(id, **args, &block)
 
         hide_on :index
@@ -9,6 +11,10 @@ module Marksmith
 
       def view_component_namespace
         "Marksmith::MarkdownField"
+      end
+
+      def gallery_enabled?
+        Avo::MediaLibrary.configuration.enabled && @media_library
       end
     end
   end

--- a/lib/marksmith/fields/markdown_field.rb
+++ b/lib/marksmith/fields/markdown_field.rb
@@ -1,8 +1,11 @@
 module Marksmith
   module Fields
     class MarkdownField < Avo::Fields::BaseField
+      attr_reader :extra_preview_params
+
       def initialize(id, **args, &block)
         @media_library = args[:media_library].nil? ? true : args[:media_library]
+        @extra_preview_params = args[:extra_preview_params] || {}
 
         super(id, **args, &block)
 


### PR DESCRIPTION
Fixes https://github.com/avo-hq/marksmith/issues/58

#### Fix 1
This change ensures that the "Attach from gallery" option doesn't rendered when the `Avo::MediaLibrary.configuration.enabled` flag is set to `false`.

---

#### Fix 2

Removes `%27` encoded char from URL

---

#### `media_library` enhancement

Adds a new `media_library` option for `markdown` field that controlls "Attach from gallery" option visibility:

Default: `true`

Usage example:

```ruby
field :body, as: :markdown, media_library: false
 ```

---

#### `file_uploads` enhancement 

Adds a new `file_uploads` option for `markdown` field that controlls "Upload files" option visibility:

Default: `true`

Usage example:

```ruby
field :body, as: :markdown, file_uploads: false
 ```
 
 ---
 
 #### `extra_preview_params` enhancement 

Adds a new `extra_preview_params` option for `markdown` field that allows to add extra preview params to `extra_preview_params` option

Default: `{}`

Usage example:

```ruby
field :body, as: :markdown, extra_preview_params: { foo: :bar }
 ```