### PR TITLE
fix: support multiple editors with the same name on a page

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,2 @@
-web: PORT=3000 bin/rails s
+web: PORT=3050 bin/rails s
 vite: bin/vite dev

--- a/app/models/marksmith/editor.rb
+++ b/app/models/marksmith/editor.rb
@@ -101,4 +101,12 @@ class Marksmith::Editor
   def value
     form&.object&.send(name) || @value || nil
   end
+
+  def textarea_id
+    "#{id}-textarea"
+  end
+
+  def preview_pane_id
+    "#{id}-preview-pane"
+  end
 end

--- a/app/views/marksmith/shared/_action_bar.html.erb
+++ b/app/views/marksmith/shared/_action_bar.html.erb
@@ -1,4 +1,4 @@
-<%= tag.markdown_toolbar for: name,
+<%= tag.markdown_toolbar for: textarea_id,
   class: class_names("ms:flex ms:flex-wrap ms:px-2 ms:py-1", "ms:pointer-events-none": disabled),
   data: { marksmith_target: "toolbar" } do
 %>

--- a/app/views/marksmith/shared/_editor.html.erb
+++ b/app/views/marksmith/shared/_editor.html.erb
@@ -15,9 +15,9 @@
     marksmith_extra_preview_params_value: editor.extra_preview_params.as_json,
     **editor.controller_data_attributes,
   } do %>
-  <%= render partial: "marksmith/shared/toolbar", locals: { name: editor.name, disabled: editor.disabled } %>
+  <%= render partial: "marksmith/shared/toolbar", locals: { textarea_id: editor.textarea_id, disabled: editor.disabled} %>
   <div class="ms:border-t ms:w-full ms:border-neutral-500 ms:flex ms:flex-1">
     <%= render partial: "marksmith/shared/editor_pane", locals: { editor: } %>
-    <%= render partial: "marksmith/shared/preview_pane", locals: { name: editor.name } %>
+    <%= render partial: "marksmith/shared/preview_pane", locals: { editor: } %>
   </div>
 <% end %>

--- a/app/views/marksmith/shared/_editor_pane.html.erb
+++ b/app/views/marksmith/shared/_editor_pane.html.erb
@@ -1,6 +1,6 @@
 <%= content_tag :div, class: "ms:flex ms:flex-1 ms:flex-col ms:size-full", data: { marksmith_target: "fieldContainer" } do %>
   <%= text_area_tag editor.field_name, editor.value,
-    id: editor.name,
+    id: editor.textarea_id,
     class: class_names(
       "ms:flex ms:flex-1 ms:border-none ms:resize-none ms:focus:outline-none ms:font-mono ms:focus:ring-0 ms:leading-normal ms:p-2 ms:text-sm ms:field-sizing-content ms:min-h-60",
       "ms:dark:bg-neutral-800 ms:dark:text-neutral-200",

--- a/app/views/marksmith/shared/_preview_pane.html.erb
+++ b/app/views/marksmith/shared/_preview_pane.html.erb
@@ -1,6 +1,6 @@
 <%= content_tag :div,
   class: "ms:hidden ms:markdown-preview ms:size-full ms:flex-1 ms:flex ms:size-full ms:p-2 ms:overflow-auto ms:bg-white ms:dark:bg-neutral-800 ms:rounded-b-md",
-  id: "markdown-preview-#{name}",
+  id: editor.preview_pane_id,
   data: {
     marksmith_target: "previewPane",
   } do %>

--- a/app/views/marksmith/shared/_toolbar.html.erb
+++ b/app/views/marksmith/shared/_toolbar.html.erb
@@ -4,5 +4,5 @@
 ) do %>
   <%= render partial: "marksmith/shared/tabs" %>
 
-  <%= render partial: "marksmith/shared/action_bar", locals: { name:, disabled: } %>
+  <%= render partial: "marksmith/shared/action_bar", locals: { textarea_id:, disabled: } %>
 <% end %>

--- a/test/dummy/app/views/static/value.html.erb
+++ b/test/dummy/app/views/static/value.html.erb
@@ -1,1 +1,13 @@
 <%= marksmith_tag :content, value: "**TEXT EXAMPLE**", id: "static-value" %>
+
+<br>
+<br>
+
+<%= turbo_frame_tag :lol do %>
+  <% if params[:load_another] %>
+    <%= marksmith_tag :content, value: "**TEXT EXAMPLE 2**", id: "static-value-2" %>
+  <% else %>
+    <%= link_to "load another editor", "/static/value?load_another=1" %>
+  <% end %>
+
+<% end %>


### PR DESCRIPTION
Fixes https://github.com/avo-hq/marksmith/issues/45

Adds special names to elements that are derived from the instance id so there are no naming conflicts.