### PR TITLE
feature: keyboard shortcuts

### DIFF
--- a/app/frontend/entrypoints/javascript/controllers/marksmith_controller.js
+++ b/app/frontend/entrypoints/javascript/controllers/marksmith_controller.js
@@ -4,6 +4,7 @@ import { Controller } from '@hotwired/stimulus'
 import { DirectUpload } from '@rails/activestorage'
 import { post } from '@rails/request.js'
 import { subscribe } from '@github/paste-markdown'
+import {install, uninstall} from '@github/hotkey'
 
 // upload code from Jeremy Smith's blog post
 // https://hybrd.co/posts/github-issue-style-file-uploader-using-stimulus-and-active-storage
@@ -29,7 +30,19 @@ export default class extends Controller {
   }
 
   connect() {
-    subscribe(this.fieldContainerTarget, { defaultPlainTextPaste: { urlLinks: true } })
+    subscribe(this.fieldElementTarget)
+
+    // Install all the hotkeys on the page
+    for (const el of document.querySelectorAll('[data-hotkey]')) {
+      install(el)
+    }
+  }
+
+  disconnect() {
+    // Uninstall all the hotkeys on the page
+    for (const el of document.querySelectorAll('[data-hotkey]')) {
+      uninstall(el)
+    }
   }
 
   switchToWrite(event) {

--- a/app/helpers/marksmith/marksmith_helper.rb
+++ b/app/helpers/marksmith/marksmith_helper.rb
@@ -26,8 +26,14 @@ module Marksmith
       )
     end
 
-    def marksmith_toolbar_button(name, **kwargs)
-      content_tag "md-#{name}", marksmith_toolbar_svg(name), title: t("marksmith.#{name.to_s.gsub("-", "_")}").humanize, class: marksmith_button_classes
+    def marksmith_toolbar_button(name, hotkey_scope: nil, hotkey: nil, **kwargs)
+      content_tag "md-#{name}", marksmith_toolbar_svg(name),
+        title: t("marksmith.#{name.to_s.gsub("-", "_")}").humanize,
+        class: marksmith_button_classes,
+        data: {
+          hotkey_scope:,
+          hotkey:
+        }
     end
 
     def marksmith_tab_classes

--- a/app/views/marksmith/shared/_action_bar.html.erb
+++ b/app/views/marksmith/shared/_action_bar.html.erb
@@ -2,9 +2,9 @@
   class: class_names("ms:flex ms:flex-wrap ms:px-2 ms:py-1", "ms:pointer-events-none": disabled),
   data: { marksmith_target: "toolbar" } do
 %>
-  <%= marksmith_toolbar_button "bold" %>
-  <%= marksmith_toolbar_button "header" %>
-  <%= marksmith_toolbar_button "italic" %>
+  <%= marksmith_toolbar_button "bold",           hotkey: "Meta+b", hotkey_scope: textarea_id %>
+  <%= marksmith_toolbar_button "header",         hotkey: "Meta+h", hotkey_scope: textarea_id %>
+  <%= marksmith_toolbar_button "italic",         hotkey: "Meta+i", hotkey_scope: textarea_id %>
   <%= marksmith_toolbar_button "quote" %>
   <%= marksmith_toolbar_button "code" %>
   <%= marksmith_toolbar_button "link" %>

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "build:css": "npx @tailwindcss/cli -i app/frontend/entrypoints/application.css -o app/assets/stylesheets/marksmith.css"
   },
   "dependencies": {
+    "@github/hotkey": "^3.1.1",
     "vite-plugin-rails": "^0.5.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -117,6 +117,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz#acad351d582d157bb145535db2a6ff53dd514b5c"
   integrity sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==
 
+"@github/hotkey@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@github/hotkey/-/hotkey-3.1.1.tgz#61fdf9993378b402bd9cdd494ee8149fe3172b0c"
+  integrity sha512-H30I6XDO3gFSgLuEuHoMBRZG9c3uCKNdAcYklL1FaZDPdU1bXfgjnpzGDPcUr0U6eGQ+T3XLY9slatwZYWL1dA==
+
 "@github/markdown-toolbar-element@^2.2.3":
   version "2.2.3"
   resolved "https://registry.npmjs.org/@github/markdown-toolbar-element/-/markdown-toolbar-element-2.2.3.tgz"
@@ -124,7 +129,7 @@
 
 "@github/paste-markdown@^1.5.3":
   version "1.5.3"
-  resolved "https://registry.npmjs.org/@github/paste-markdown/-/paste-markdown-1.5.3.tgz"
+  resolved "https://registry.yarnpkg.com/@github/paste-markdown/-/paste-markdown-1.5.3.tgz#75b404fbbae173e7c7f0ab1d7a920623b7eadc0c"
   integrity sha512-PzZ1b3PaqBzYqbT4fwKEhiORf38h2OcGp2+JdXNNM7inZ7egaSmfmhyNkQILpqWfS0AYtRS3CDq6z03eZ8yOMQ==
 
 "@hotwired/stimulus@^3.2.2":


### PR DESCRIPTION
Closes #4

For now the editor supports shortcuts for bold, header, and italic.
We're open to adding more shortcuts.