### PR TITLE
Fix issue with namespacing

### DIFF
--- a/app/models/marksmith/renderer.rb
+++ b/app/models/marksmith/renderer.rb
@@ -17,7 +17,7 @@ module Marksmith
     def render_commonmarker
       # commonmarker expects an utf-8 encoded string
       body = @body.to_s.dup.force_encoding("utf-8")
-      Commonmarker.to_html(body)
+      ::Commonmarker.to_html(body)
     end
 
     def render_redcarpet
@@ -39,7 +39,7 @@ module Marksmith
 
     def render_kramdown
       body = @body.to_s.dup.force_encoding("utf-8")
-      Kramdown::Document.new(body).to_html
+      ::Kramdown::Document.new(body).to_html
     end
   end
 end


### PR DESCRIPTION
Was encountering an error. 

```
NameError (uninitialized constant Marksmith::Renderer::Commonmarker):

marksmith (0.4.4) app/models/marksmith/renderer.rb:20:in render_commonmarker'
marksmith (0.4.4) app/models/marksmith/renderer.rb:9:in render'
marksmith (0.4.4) app/controllers/marksmith/markdown_previews_controller.rb:4:in create'
actionpack (8.0.2) lib/action_controller/metal/basic_implicit_render.rb:8:in send_action'
actionpack (8.0.2) lib/abstract_controller/base.rb:226:in process_action'
actionpack (8.0.2) lib/action_controller/metal/rendering.rb:193:in process_action'
actionpack (8.0.2) lib/abstract_controller/callbacks.rb:261:in block in process_action'
activesupport (8.0.2) lib/active_support/callbacks.rb:120:in block in run_callbacks'
turbo-rails (2.0.13) lib/turbo-rails.rb:24:in with_request_id'
turbo-rails (2.0.13) app/controllers/concerns/turbo/request_id_tracking.rb:10:in turbo_tracking_request_id'
activesupport (8.0.2) lib/active_support/callbacks.rb:129:in block in run_callbacks'
actiontext (8.0.2) lib/action_text/rendering.rb:25:in with_renderer'
actiontext (8.0.2) lib/action_text/engine.rb:71:in `block (4 levels) in <class:Engine>'
```