### PR TITLE
Add rows parameter to editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Marksmith accepts a few configuration options.
 
 ### Field options
 
-The field supports a few of the regular options like `disabled`, `placeholder`, `autofocus`, `style`, `class`, `data`, and `value`, but also a custom one.
+The field supports a few of the regular options like `disabled`, `placeholder`, `autofocus`, `style`, `class`, `data`, `rows` and `value`, but also a custom one.
 
 `extra_preview_params` - Sends extra params to the preview renderer.
 

--- a/app/models/marksmith/editor.rb
+++ b/app/models/marksmith/editor.rb
@@ -13,7 +13,8 @@ class Marksmith::Editor
     :style,
     :gallery,
     :kwargs,
-    :id
+    :id,
+    :rows
 
   def initialize(name:,
     upload_url: nil,
@@ -31,6 +32,7 @@ class Marksmith::Editor
     value: nil,
     id: "marksmith-instance-#{rand(1000..9999)}",
     gallery: {},
+    rows: 11,
     **kwargs)
     @name = name
     @kwargs = kwargs
@@ -50,6 +52,7 @@ class Marksmith::Editor
     @value = value
     @id = id
     @gallery = gallery
+    @rows = rows
   end
 
   def gallery_enabled

--- a/app/views/marksmith/shared/_editor_pane.html.erb
+++ b/app/views/marksmith/shared/_editor_pane.html.erb
@@ -2,7 +2,7 @@
   <%= text_area_tag editor.field_name, editor.value,
     id: editor.textarea_id,
     class: class_names(
-      "ms:flex ms:flex-1 ms:border-none ms:resize-none ms:focus:outline-none ms:font-mono ms:focus:ring-0 ms:leading-normal ms:p-2 ms:text-sm ms:field-sizing-content ms:min-h-60",
+      "ms:flex ms:flex-1 ms:border-none ms:resize-none ms:focus:outline-none ms:font-mono ms:focus:ring-0 ms:leading-normal ms:p-2 ms:text-sm ms:field-sizing-content",
       "ms:dark:bg-neutral-800 ms:dark:text-neutral-200",
       editor.classes
     ),
@@ -14,7 +14,8 @@
     disabled: editor.disabled,
     placeholder: editor.placeholder,
     autofocus: editor.autofocus,
-    style: editor.style
+    style: editor.style,
+    rows: editor.rows
   %>
   <% toolbar_button_classes = "ms:cursor-pointer ms:hover:bg-neutral-200 ms:px-1 ms:py-px ms:rounded ms:text-sm ms:dark:text-neutral-300 ms:dark:hover:bg-neutral-600" %>
   <div class="ms:flex ms:flex-1 ms:flex-grow ms:space-x-2 ms:py-1 ms:border-t ms:border-neutral-500 ms:px-2 ms:font-sans ms:text-sm ms:p-2 ms:dark:bg-neutral-800 ms:dark:text-neutral-300 ms:rounded-b-md">


### PR DESCRIPTION
Motivation:
Easy way to have more control on the appearance of the editor.

Default is `11` to approximatively match with the former value `min-h-60`.

EDIT: for some reason, while it works on Safari, it doesn't work on Chrome based browsers. Will investigate later.