### PR TITLE
feature: tab to indent

### DIFF
--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -20,6 +20,10 @@
 .marksmith,
 .marksmith * {
   box-sizing: border-box;
+
+  & textarea.marksmith-textarea {
+    tab-size: var(--tab-size, 4);
+  }
 }
 
 .ms\:button-spinner {

--- a/app/frontend/entrypoints/javascript/controllers/marksmith_controller.js
+++ b/app/frontend/entrypoints/javascript/controllers/marksmith_controller.js
@@ -135,6 +135,18 @@ export default class extends Controller {
     this.editor?.chain().focus().setAttachment(editorAttachments).run();
   }
 
+  indent(event) {
+    event.preventDefault()
+    // add a tab before the current cursor position
+    const start = this.fieldElementTarget.selectionStart
+    const end = this.fieldElementTarget.selectionEnd
+    const text = this.fieldElementTarget.value
+    const newText = text.slice(0, start) + '\t' + text.slice(start, end) + text.slice(end)
+    this.fieldElementTarget.value = newText
+    this.fieldElementTarget.selectionStart = start + 1
+    this.fieldElementTarget.selectionEnd = end + 1
+  }
+
   #uploadFiles(files) {
     Array.from(files).forEach((file) => this.#uploadFile(file))
   }

--- a/app/views/marksmith/shared/_editor_pane.html.erb
+++ b/app/views/marksmith/shared/_editor_pane.html.erb
@@ -2,12 +2,12 @@
   <%= text_area_tag editor.field_name, editor.value,
     id: editor.textarea_id,
     class: class_names(
-      "ms:flex ms:flex-1 ms:border-none ms:resize-none ms:focus:outline-none ms:font-mono ms:focus:ring-0 ms:leading-normal ms:p-2 ms:text-sm ms:field-sizing-content ms:min-h-60",
+      "marksmith-textarea ms:flex ms:flex-1 ms:border-none ms:resize-none ms:focus:outline-none ms:font-mono ms:focus:ring-0 ms:leading-normal ms:p-2 ms:text-sm ms:field-sizing-content ms:min-h-60",
       "ms:dark:bg-neutral-800 ms:dark:text-neutral-200",
       editor.classes
     ),
     data: {
-      action: "drop->marksmith#dropUpload paste->marksmith#pasteUpload",
+      action: "drop->marksmith#dropUpload paste->marksmith#pasteUpload keydown.tab->marksmith#indent",
       marksmith_target: "fieldElement",
       **editor.data_attributes
     },


### PR DESCRIPTION
Pressing the `tab` key now indents the content instead of jumping out of the editor to focus the next element on the page.