### PR TITLE
Add semantic class names to editor components

### DIFF
--- a/app/views/marksmith/shared/_action_bar.html.erb
+++ b/app/views/marksmith/shared/_action_bar.html.erb
@@ -1,5 +1,5 @@
 <%= tag.markdown_toolbar for: textarea_id,
-  class: class_names("ms:flex ms:flex-wrap ms:px-2 ms:py-1", "ms:pointer-events-none": disabled),
+  class: class_names("marksmith-action-bar ms:flex ms:flex-wrap ms:px-2 ms:py-1", "ms:pointer-events-none": disabled),
   data: { marksmith_target: "toolbar" } do
 %>
   <%= marksmith_toolbar_button "bold",           hotkey: "Meta+b", hotkey_scope: textarea_id %>

--- a/app/views/marksmith/shared/_editor.html.erb
+++ b/app/views/marksmith/shared/_editor.html.erb
@@ -1,6 +1,6 @@
 <%= content_tag :div,
   id: editor.id,
-  class: "marksmith ms:block ms:flex-col ms:w-full ms:border ms:border-neutral-500 ms:rounded-md ms:@container ms:focus-within:outline-2 ms:outline-blue-500 ms:-outline-offset-1",
+  class: "marksmith-editor-wrapper marksmith ms:block ms:flex-col ms:w-full ms:border ms:border-neutral-500 ms:rounded-md ms:@container ms:focus-within:outline-2 ms:outline-blue-500 ms:-outline-offset-1",
   data: {
     controller: "marksmith list-continuation",
     action: "
@@ -16,7 +16,7 @@
     **editor.controller_data_attributes,
   } do %>
   <%= render partial: "marksmith/shared/toolbar", locals: { textarea_id: editor.textarea_id, disabled: editor.disabled} %>
-  <div class="ms:border-t ms:w-full ms:border-neutral-500 ms:flex ms:flex-1">
+  <div class="marksmith-editor-content ms:border-t ms:w-full ms:border-neutral-500 ms:flex ms:flex-1">
     <%= render partial: "marksmith/shared/editor_pane", locals: { editor: } %>
     <%= render partial: "marksmith/shared/preview_pane", locals: { editor: } %>
   </div>

--- a/app/views/marksmith/shared/_editor_pane.html.erb
+++ b/app/views/marksmith/shared/_editor_pane.html.erb
@@ -7,7 +7,7 @@
       editor.classes
     ),
     data: {
-      action: "drop->marksmith#dropUpload paste->marksmith#pasteUpload",
+      action: "drop->marksmith#dropUpload paste->marksmith#pasteUpload keydown.tab->marksmith#indent",
       marksmith_target: "fieldElement",
       **editor.data_attributes
     },

--- a/app/views/marksmith/shared/_editor_pane.html.erb
+++ b/app/views/marksmith/shared/_editor_pane.html.erb
@@ -1,4 +1,4 @@
-<%= content_tag :div, class: "ms:flex ms:flex-1 ms:flex-col ms:size-full", data: { marksmith_target: "fieldContainer" } do %>
+<%= content_tag :div, class: "marksmith-editor-pane ms:flex ms:flex-1 ms:flex-col ms:size-full", data: { marksmith_target: "fieldContainer" } do %>
   <%= text_area_tag editor.field_name, editor.value,
     id: editor.textarea_id,
     class: class_names(
@@ -7,7 +7,7 @@
       editor.classes
     ),
     data: {
-      action: "drop->marksmith#dropUpload paste->marksmith#pasteUpload keydown.tab->marksmith#indent",
+      action: "drop->marksmith#dropUpload paste->marksmith#pasteUpload",
       marksmith_target: "fieldElement",
       **editor.data_attributes
     },
@@ -17,17 +17,17 @@
     style: editor.style
   %>
   <% toolbar_button_classes = "ms:cursor-pointer ms:hover:bg-neutral-200 ms:px-1 ms:py-px ms:rounded ms:text-sm ms:dark:text-neutral-300 ms:dark:hover:bg-neutral-600" %>
-  <div class="ms:flex ms:flex-1 ms:flex-grow ms:space-x-2 ms:py-1 ms:border-t ms:border-neutral-500 ms:px-2 ms:font-sans ms:text-sm ms:p-2 ms:dark:bg-neutral-800 ms:dark:text-neutral-300 ms:rounded-b-md">
-    <%= link_to "https://docs.github.com/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax", target: "_blank", class: class_names("ms:flex ms:items-center ms:text-neutral-800 ms:no-underline ms:gap-1", toolbar_button_classes) do %>
+  <div class="marksmith-bottom-toolbar ms:flex ms:flex-1 ms:flex-grow ms:space-x-2 ms:py-1 ms:border-t ms:border-neutral-500 ms:px-2 ms:font-sans ms:text-sm ms:p-2 ms:dark:bg-neutral-800 ms:dark:text-neutral-300 ms:rounded-b-md">
+    <%= link_to "https://docs.github.com/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax", target: "_blank", class: class_names("marksmith-help-link ms:flex ms:items-center ms:text-neutral-800 ms:no-underline ms:gap-1", toolbar_button_classes) do %>
       <%= marksmith_inline_svg("app/assets/images/marksmith/svgs/markdown.svg") %> <span><%= t("marksmith.markdown_is_supported").humanize %></span>
     <% end %>
     <% if editor.enable_file_uploads %>
-      <%= button_tag data: { action: "click->marksmith#buttonUpload" }, class: class_names("ms:bg-none ms:border-none ms:bg-transparent ms:text-neutral-600 ms:items-center ms:flex ms:gap-1", toolbar_button_classes) do %>
+      <%= button_tag data: { action: "click->marksmith#buttonUpload" }, class: class_names("marksmith-upload-button ms:bg-none ms:border-none ms:bg-transparent ms:text-neutral-600 ms:items-center ms:flex ms:gap-1", toolbar_button_classes) do %>
         <%= marksmith_inline_svg("app/assets/images/marksmith/svgs/paperclip.svg") %> <span><%= t("marksmith.upload_files").humanize %></span>
       <% end %>
     <% end %>
     <% if editor.gallery_enabled %>
-      <%= link_to editor.gallery_full_path, data: { turbo_frame: editor.gallery_turbo_frame }, class: class_names("ms:flex ms:items-center ms:text-neutral-800 ms:no-underline ms:gap-1", toolbar_button_classes) do %>
+      <%= link_to editor.gallery_full_path, data: { turbo_frame: editor.gallery_turbo_frame }, class: class_names("marksmith-gallery-link ms:flex ms:items-center ms:text-neutral-800 ms:no-underline ms:gap-1", toolbar_button_classes) do %>
         <%= marksmith_inline_svg("app/assets/images/marksmith/svgs/gallery.svg") %> <span><%= t("marksmith.attach_from_gallery").humanize %></span>
       <% end %>
     <% end %>

--- a/app/views/marksmith/shared/_loading_indicator.html.erb
+++ b/app/views/marksmith/shared/_loading_indicator.html.erb
@@ -1,4 +1,4 @@
-<div class="ms:button-spinner">
-  <div class="double-bounce1"></div>
-  <div class="double-bounce2"></div>
+<div class="marksmith-loading-indicator ms:button-spinner">
+  <div class="marksmith-loading-bounce1 double-bounce1"></div>
+  <div class="marksmith-loading-bounce2 double-bounce2"></div>
 </div>

--- a/app/views/marksmith/shared/_preview_pane.html.erb
+++ b/app/views/marksmith/shared/_preview_pane.html.erb
@@ -1,5 +1,5 @@
 <%= content_tag :div,
-  class: "ms:hidden ms:markdown-preview ms:size-full ms:flex-1 ms:flex ms:size-full ms:p-2 ms:overflow-auto ms:bg-white ms:dark:bg-neutral-800 ms:rounded-b-md",
+  class: "marksmith-preview-pane ms:hidden ms:markdown-preview ms:size-full ms:flex-1 ms:flex ms:size-full ms:p-2 ms:overflow-auto ms:bg-white ms:dark:bg-neutral-800 ms:rounded-b-md",
   id: editor.preview_pane_id,
   data: {
     marksmith_target: "previewPane",

--- a/app/views/marksmith/shared/_rendered_body.html.erb
+++ b/app/views/marksmith/shared/_rendered_body.html.erb
@@ -1,3 +1,3 @@
-<%= content_tag :div, class: "ms:block ms:w-full ms:prose ms:max-w-none ms:prose-neutral ms:dark:prose-invert" do %>
+<%= content_tag :div, class: "marksmith-rendered-body ms:block ms:w-full ms:prose ms:max-w-none ms:prose-neutral ms:dark:prose-invert" do %>
   <%= sanitize(body, tags: %w(table th tr td span) + ActionView::Helpers::SanitizeHelper.sanitizer_vendor.safe_list_sanitizer.allowed_tags.to_a) %>
 <% end %>

--- a/app/views/marksmith/shared/_tabs.html.erb
+++ b/app/views/marksmith/shared/_tabs.html.erb
@@ -1,8 +1,8 @@
-<div class="ms:flex-1 ms:flex ms:items:center">
-  <button class="<%= marksmith_tab_classes %> active" data-action="click->marksmith#switchToWrite" data-marksmith-target="writeTabButton" type="button">
+<div class="marksmith-tabs ms:flex-1 ms:flex ms:items:center">
+  <button class="marksmith-tab marksmith-write-tab <%= marksmith_tab_classes %> active" data-action="click->marksmith#switchToWrite" data-marksmith-target="writeTabButton" type="button">
     <%= t('marksmith.write').humanize %>
   </button>
-  <button class="<%= marksmith_tab_classes %>" data-action="click->marksmith#switchToPreview" data-marksmith-target="previewTabButton" type="button">
+  <button class="marksmith-tab marksmith-preview-tab <%= marksmith_tab_classes %>" data-action="click->marksmith#switchToPreview" data-marksmith-target="previewTabButton" type="button">
     <%= t('marksmith.preview').humanize %>
   </button>
 </div>

--- a/app/views/marksmith/shared/_toolbar.html.erb
+++ b/app/views/marksmith/shared/_toolbar.html.erb
@@ -1,5 +1,5 @@
 <%= tag.div class: class_names(
-  "ms:flex-1 ms:flex-col-reverse ms:@md:flex-row ms:grow ms:flex  ms:justify-bewteen ms:bg-neutral-50 ms:rounded-t-md ms:gap-y-1",
+  "marksmith-toolbar ms:flex-1 ms:flex-col-reverse ms:@md:flex-row ms:grow ms:flex  ms:justify-bewteen ms:bg-neutral-50 ms:rounded-t-md ms:gap-y-1",
   "ms:dark:bg-neutral-700 ms:dark:text-neutral-200"
 ) do %>
   <%= render partial: "marksmith/shared/tabs" %>


### PR DESCRIPTION
Currently, it's messy to write CSS to make a Marksmith instance integrate nicely with the styling of one's own app. The Marksmith views don't incorporate any semantic class names to make it easy to target them in CSS. i.e. it requires the use of messy selectors to target the various pieces that make up a Marksmith editor or preview pane.

This PR updates all of the shared views with classes that can be hooked into with application CSS to adjust how Marksmith looks.

![image](https://github.com/user-attachments/assets/c9928aa9-3813-4c05-a5cb-50870bf7b3f4)

An example of how I am using this.  That's the dark mode for the application I am working on.

If I haven't missed anything, here's the list of everything that I added:

## Main Components

* **marksmith-editor-wrapper** - The outermost editor container
* **marksmith-toolbar** - Top toolbar containing tabs and action buttons
* **marksmith-editor-content** - Main content area with editor and preview panes

## Tabs & Navigation

* **marksmith-tabs** - Tab container
* **marksmith-tab** - Base class for all tabs
* **marksmith-write-tab** - Write tab specifically
* **marksmith-preview-tab** - Preview tab specifically

## Editor Components

* **marksmith-editor-pane** - Editor pane container
* **marksmith-textarea** - The main markdown textarea
* **marksmith-preview-pane** - Preview pane container
* **marksmith-rendered-body** - Rendered markdown content

## Toolbars & Controls

* **marksmith-action-bar** - Markdown formatting toolbar
* **marksmith-bottom-toolbar** - Bottom toolbar with help/upload links
* **marksmith-help-link** - Markdown help link
* **marksmith-upload-button** - File upload button
* **marksmith-gallery-link** - Gallery attachment link

## Loading States

* **marksmith-loading-indicator** - Loading spinner container
* **marksmith-loading-bounce1/2** - Spinner animation elements

