### PR TITLE
Support footnotes for redcarpet renderer

### DIFF
--- a/app/models/marksmith/renderer.rb
+++ b/app/models/marksmith/renderer.rb
@@ -33,7 +33,8 @@ module Marksmith
         underline: true,
         highlight: true,
         quote: true,
-        with_toc_data: true
+        with_toc_data: true,
+        footnotes: true
       ).render(@body)
     end
 


### PR DESCRIPTION
A minor enhancement, so it supports footnotes similar to what github offers. https://github.blog/changelog/2021-09-30-footnotes-now-supported-in-markdown-fields/

<img width="138" height="44" alt="Screenshot 2025-09-17 at 15 19 09" src="https://github.com/user-attachments/assets/11cbf484-2980-4fcc-8d0a-4267f081522f" />