### PR TITLE
chore: drop `ActiveSupport::Configurable`

### DIFF
--- a/lib/marksmith/configuration.rb
+++ b/lib/marksmith/configuration.rb
@@ -1,10 +1,8 @@
 module Marksmith
   class Configuration
-    include ActiveSupport::Configurable
-
-    config_accessor(:automatically_mount_engine) { true }
-    config_accessor(:mount_path) { "/marksmith" }
-    config_accessor(:parser) { "commonmarker" }
+    class_attribute :automatically_mount_engine, default: true
+    class_attribute :mount_path, default: "/marksmith"
+    class_attribute :parser, default: "commonmarker"
   end
 
   def self.configuration


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

```bash
DEPRECATION WARNING: ActiveSupport::Configurable is deprecated without replacement, and will be removed in Rails 8.2.

You can emulate the previous behavior with `class_attribute`.
```