### PR TITLE
Add configurable `redcarpet` options to `Marksmith::Configuration`

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,19 @@ Marksmith.configure do |config|
 end
 ```
 
+If you're using `redcarpet`, you can override the default parser flags through configuration. The defaults match the built-in behavior.
+
+```ruby
+# config/initializers/marksmith.rb
+Marksmith.configure do |config|
+  config.parser = "redcarpet"
+  config.redcarpet_options = {
+    underline: false,
+    highlight: false
+  }
+end
+```
+
 ### Add your own renderer
 
 You can completely customize the renderer by overriding the `Marksmith::Renderer` model.

--- a/README.md
+++ b/README.md
@@ -207,6 +207,17 @@ Marksmith.configure do |config|
 end
 ```
 
+Or override individual flags directly:
+
+```ruby
+# config/initializers/marksmith.rb
+Marksmith.configure do |config|
+  config.parser = "redcarpet"
+  config.redcarpet_options.underline = false
+  config.redcarpet_options.highlight = false
+end
+```
+
 ### Add your own renderer
 
 You can completely customize the renderer by overriding the `Marksmith::Renderer` model.

--- a/app/models/marksmith/renderer.rb
+++ b/app/models/marksmith/renderer.rb
@@ -23,7 +23,7 @@ module Marksmith
     def render_redcarpet
       ::Redcarpet::Markdown.new(
         ::Redcarpet::Render::HTML,
-        Marksmith.configuration.redcarpet_options
+        Marksmith.configuration.redcarpet_options.to_h
       ).render(@body)
     end
 

--- a/app/models/marksmith/renderer.rb
+++ b/app/models/marksmith/renderer.rb
@@ -23,17 +23,7 @@ module Marksmith
     def render_redcarpet
       ::Redcarpet::Markdown.new(
         ::Redcarpet::Render::HTML,
-        tables: true,
-        lax_spacing: true,
-        fenced_code_blocks: true,
-        space_after_headers: true,
-        hard_wrap: true,
-        autolink: true,
-        strikethrough: true,
-        underline: true,
-        highlight: true,
-        quote: true,
-        with_toc_data: true
+        Marksmith.configuration.redcarpet_options
       ).render(@body)
     end
 

--- a/lib/generators/marksmith/templates/initializer/marksmith.tt
+++ b/lib/generators/marksmith/templates/initializer/marksmith.tt
@@ -1,4 +1,8 @@
 # Marksmith.configure do |config|
 #   config.automatically_mount_engine = true
 #   config.mount_path = "/marksmith"
+#   config.parser = "commonmarker"
+#   config.redcarpet_options = {
+#     underline: false
+#   }
 # end

--- a/lib/generators/marksmith/templates/initializer/marksmith.tt
+++ b/lib/generators/marksmith/templates/initializer/marksmith.tt
@@ -1,8 +1,4 @@
 # Marksmith.configure do |config|
 #   config.automatically_mount_engine = true
 #   config.mount_path = "/marksmith"
-#   config.parser = "commonmarker"
-#   config.redcarpet_options = {
-#     underline: false
-#   }
 # end

--- a/lib/marksmith/configuration.rb
+++ b/lib/marksmith/configuration.rb
@@ -34,7 +34,9 @@ module Marksmith
       end
 
       def self.to_h
-        DEFAULTS.keys.index_with { |key| public_send(key) }
+        DEFAULTS.keys.each_with_object({}) do |key, hash|
+          hash[key] = public_send(key)
+        end
       end
     end
 

--- a/lib/marksmith/configuration.rb
+++ b/lib/marksmith/configuration.rb
@@ -1,21 +1,47 @@
 module Marksmith
   class Configuration
+    class RedcarpetOptions
+      DEFAULTS = {
+        tables: true,
+        lax_spacing: true,
+        fenced_code_blocks: true,
+        space_after_headers: true,
+        hard_wrap: true,
+        autolink: true,
+        strikethrough: true,
+        underline: true,
+        highlight: true,
+        quote: true,
+        with_toc_data: true
+      }.freeze
+
+      DEFAULTS.each do |name, default|
+        class_attribute name, default: default
+      end
+
+      def self.merge(options)
+        options.to_h.each do |key, value|
+          writer = "#{key}="
+
+          unless respond_to?(writer)
+            raise ArgumentError, "Unknown Redcarpet option: #{key}"
+          end
+
+          public_send(writer, value)
+        end
+
+        self
+      end
+
+      def self.to_h
+        DEFAULTS.keys.index_with { |key| public_send(key) }
+      end
+    end
+
     class_attribute :automatically_mount_engine, default: true
     class_attribute :mount_path, default: "/marksmith"
     class_attribute :parser, default: "commonmarker"
-    class_attribute :redcarpet_options, default: {
-      tables: true,
-      lax_spacing: true,
-      fenced_code_blocks: true,
-      space_after_headers: true,
-      hard_wrap: true,
-      autolink: true,
-      strikethrough: true,
-      underline: true,
-      highlight: true,
-      quote: true,
-      with_toc_data: true
-    }
+    class_attribute :redcarpet_options, default: RedcarpetOptions
 
     def redcarpet_options=(options)
       self.class.redcarpet_options = redcarpet_options.merge(options.to_h)

--- a/lib/marksmith/configuration.rb
+++ b/lib/marksmith/configuration.rb
@@ -3,6 +3,23 @@ module Marksmith
     class_attribute :automatically_mount_engine, default: true
     class_attribute :mount_path, default: "/marksmith"
     class_attribute :parser, default: "commonmarker"
+    class_attribute :redcarpet_options, default: {
+      tables: true,
+      lax_spacing: true,
+      fenced_code_blocks: true,
+      space_after_headers: true,
+      hard_wrap: true,
+      autolink: true,
+      strikethrough: true,
+      underline: true,
+      highlight: true,
+      quote: true,
+      with_toc_data: true
+    }
+
+    def redcarpet_options=(options)
+      self.class.redcarpet_options = redcarpet_options.merge(options.to_h)
+    end
   end
 
   def self.configuration

--- a/test/lib/marksmith/configuration_test.rb
+++ b/test/lib/marksmith/configuration_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+
+class ConfigurationTest < ActiveSupport::TestCase
+  def setup
+    @original_redcarpet_options = Marksmith.configuration.redcarpet_options.to_h
+  end
+
+  def teardown
+    Marksmith.configuration.redcarpet_options = @original_redcarpet_options
+  end
+
+  test "redcarpet options expose defaults" do
+    assert_equal Marksmith::Configuration::RedcarpetOptions::DEFAULTS, Marksmith.configuration.redcarpet_options.to_h
+  end
+
+  test "redcarpet options hash assignment merges with existing options" do
+    Marksmith.configuration.redcarpet_options = { underline: false }
+    Marksmith.configuration.redcarpet_options = { highlight: false }
+
+    assert_equal false, Marksmith.configuration.redcarpet_options.underline
+    assert_equal false, Marksmith.configuration.redcarpet_options.highlight
+    assert_equal true, Marksmith.configuration.redcarpet_options.tables
+  end
+
+  test "redcarpet options can be overridden through DSL setters" do
+    Marksmith.configuration.redcarpet_options.underline = false
+    Marksmith.configuration.redcarpet_options.highlight = false
+
+    assert_equal false, Marksmith.configuration.redcarpet_options.underline
+    assert_equal false, Marksmith.configuration.redcarpet_options.highlight
+    assert_equal true, Marksmith.configuration.redcarpet_options.tables
+  end
+
+  test "redcarpet options reject unknown keys" do
+    error = assert_raises(ArgumentError) do
+      Marksmith.configuration.redcarpet_options = { invalid_option: true }
+    end
+
+    assert_equal "Unknown Redcarpet option: invalid_option", error.message
+  end
+end

--- a/test/lib/marksmith/redcarpet_helper_test.rb
+++ b/test/lib/marksmith/redcarpet_helper_test.rb
@@ -4,7 +4,14 @@ class RedcarpetHelperTest < ActiveSupport::TestCase
   include Marksmith::MarksmithHelper
 
   def setup
+    @original_parser = Marksmith.configuration.parser
+    @original_redcarpet_options = Marksmith.configuration.redcarpet_options.dup
     Marksmith.configuration.parser = "redcarpet"
+  end
+
+  def teardown
+    Marksmith.configuration.parser = @original_parser
+    Marksmith.configuration.redcarpet_options = @original_redcarpet_options
   end
 
   test "marksmithed#renders simple markdown" do
@@ -141,5 +148,27 @@ Paragraph two"
     expected = ""
 
     assert_equal expected, marksmithed(body.to_s)
+  end
+
+  test "marksmithed#allows overriding redcarpet options" do
+    Marksmith.configuration.redcarpet_options = {
+      underline: false,
+      highlight: false
+    }
+
+    body = "This is _underline_ and ==highlighted== text."
+    expected = "<p>This is <em>underline</em> and ==highlighted== text.</p>\n"
+
+    assert_equal expected, marksmithed(body)
+  end
+
+  test "marksmithed#merges repeated redcarpet option overrides" do
+    Marksmith.configuration.redcarpet_options = { underline: false }
+    Marksmith.configuration.redcarpet_options = { highlight: false }
+
+    body = "This is _underline_ and ==highlighted== text."
+    expected = "<p>This is <em>underline</em> and ==highlighted== text.</p>\n"
+
+    assert_equal expected, marksmithed(body)
   end
 end

--- a/test/lib/marksmith/redcarpet_helper_test.rb
+++ b/test/lib/marksmith/redcarpet_helper_test.rb
@@ -5,7 +5,7 @@ class RedcarpetHelperTest < ActiveSupport::TestCase
 
   def setup
     @original_parser = Marksmith.configuration.parser
-    @original_redcarpet_options = Marksmith.configuration.redcarpet_options.dup
+    @original_redcarpet_options = Marksmith.configuration.redcarpet_options.to_h
     Marksmith.configuration.parser = "redcarpet"
   end
 
@@ -155,16 +155,6 @@ Paragraph two"
       underline: false,
       highlight: false
     }
-
-    body = "This is _underline_ and ==highlighted== text."
-    expected = "<p>This is <em>underline</em> and ==highlighted== text.</p>\n"
-
-    assert_equal expected, marksmithed(body)
-  end
-
-  test "marksmithed#merges repeated redcarpet option overrides" do
-    Marksmith.configuration.redcarpet_options = { underline: false }
-    Marksmith.configuration.redcarpet_options = { highlight: false }
 
     body = "This is _underline_ and ==highlighted== text."
     expected = "<p>This is <em>underline</em> and ==highlighted== text.</p>\n"


### PR DESCRIPTION
### Summary

Dear Marksmith Team,

For historical reasons, I use `underline: false` in my project, and for consistency it would be useful to be able to override Marksmith's `redcarpet` settings. I think this would be generally useful for other applications as well.

This PR makes `Marksmith::Renderer#render_redcarpet` configurable through `Marksmith.configure`.

Instead of hardcoding the `Redcarpet::Markdown` flags inside the renderer, it introduces `config.redcarpet_options`, with defaults matching the current behavior. This keeps existing rendering unchanged while allowing applications to override specific `redcarpet` options from the initializer.

The API supports both assigning a hash of overrides and changing individual flags directly on the options object, for example `config.redcarpet_options = { underline: false }` or `config.redcarpet_options.underline = false`.

### Changes

- add `Marksmith::Configuration::RedcarpetOptions` to encapsulate default `redcarpet` flags
- add `config.redcarpet_options` to `Marksmith::Configuration`
- update `Marksmith::Renderer#render_redcarpet` to read options from configuration
- add focused configuration tests for default values, hash overrides, DSL-style overrides, and invalid keys
- keep renderer tests focused on rendering behavior, with coverage for configured `redcarpet` overrides
- document the new configuration in the README

### Example

```ruby
Marksmith.configure do |config|
  config.parser = "redcarpet"
  config.redcarpet_options = {
    underline: false,
    highlight: false
  }
end
```

Or:

```ruby
Marksmith.configure do |config|
  config.parser = "redcarpet"
  config.redcarpet_options.underline = false
  config.redcarpet_options.highlight = false
end
```