### PR TITLE
fix: wonky tab border and dummy tweaks

### DIFF
--- a/app/helpers/marksmith/marksmith_helper.rb
+++ b/app/helpers/marksmith/marksmith_helper.rb
@@ -42,11 +42,11 @@ module Marksmith
         "marksmith-toggle-button ms:text-sm ms:hover:bg-neutral-300 ms:text-sm ms:font-medium ms:cursor-pointer ms:text-neutral-500 ms:px-3",
         # borders
         "ms:bg-transparent ms:hover:bg-transparent",
-        "ms:-my-px ms:-ml-px ms:border ms:border-transparent",
-        "ms:h-[calc(100%+3px)] ms:border-b-none",
+        "ms:-mt-px ms:-mb-px ms:-ml-px ms:border ms:border-transparent",
+        "ms:h-[calc(100%+2px)] ms:border-b-none",
         # "ms:border-b-neutral-00",
         # active classes
-        "ms:[.active]:bg-white ms:[.active]:text-neutral-900 ms:dark:[.active]:text-neutral-300 ms:[.active]:dark:bg-neutral-800 ms:[.active]:dark:border-neutral-500 ms:[.active]:rounded-t-md ms:[.active]:border-neutral-500",
+        "ms:[.active]:bg-white ms:[.active]:text-neutral-900 ms:dark:[.active]:text-neutral-300 ms:[.active]:dark:bg-neutral-800 ms:[.active]:dark:border-neutral-500 ms:[.active]:rounded-t-md ms:[.active]:border-neutral-500 ms:[.active]:border-b-transparent",
 
       )
     end

--- a/app/views/marksmith/shared/_editor_pane.html.erb
+++ b/app/views/marksmith/shared/_editor_pane.html.erb
@@ -2,7 +2,7 @@
   <%= text_area_tag editor.field_name, editor.value,
     id: editor.textarea_id,
     class: class_names(
-      "marksmith-textarea ms:flex ms:flex-1 ms:border-none ms:resize-none ms:focus:outline-none ms:font-mono ms:focus:ring-0 ms:leading-normal ms:p-2 ms:text-sm ms:field-sizing-content ms:min-h-60",
+      "marksmith-textarea ms:flex ms:flex-1 ms:border-none ms:resize-none ms:focus:outline-none ms:font-mono ms:focus:ring-0 ms:leading-normal ms:p-2 ms:text-sm ms:field-sizing-content ms:min-h-60 ms:rounded-none",
       "ms:dark:bg-neutral-800 ms:dark:text-neutral-200",
       editor.classes
     ),

--- a/test/dummy/app/views/layouts/application.html.erb
+++ b/test/dummy/app/views/layouts/application.html.erb
@@ -26,6 +26,25 @@
     <% else %>
       <%= marksmith_asset_tags %>
     <% end %>
+
+    <script src="https://unpkg.com/@tailwindcss/browser@4"></script>
+
+    <style>
+      .markdown-body h1 { font-size: 1.75rem; font-weight: 700; margin: 1.5rem 0 0.75rem; }
+      .markdown-body h2 { font-size: 1.4rem; font-weight: 700; margin: 1.25rem 0 0.5rem; }
+      .markdown-body h3 { font-size: 1.15rem; font-weight: 600; margin: 1rem 0 0.5rem; }
+      .markdown-body p { margin: 0.75rem 0; }
+      .markdown-body ul, .markdown-body ol { padding-left: 1.5rem; margin: 0.75rem 0; }
+      .markdown-body ul { list-style: disc; }
+      .markdown-body ol { list-style: decimal; }
+      .markdown-body a { color: #1d4ed8; text-decoration: underline; }
+      .markdown-body code { background: #f4f4f5; padding: 0.1rem 0.35rem; border-radius: 0.25rem; font-size: 0.9em; }
+      .markdown-body pre { background: #18181b; color: #f4f4f5; padding: 1rem; border-radius: 0.5rem; overflow-x: auto; margin: 1rem 0; }
+      .markdown-body pre code { background: transparent; padding: 0; color: inherit; }
+      .markdown-body blockquote { border-left: 3px solid #d4d4d8; padding-left: 1rem; color: #525252; margin: 1rem 0; }
+      .markdown-body img { max-width: 100%; border-radius: 0.5rem; margin: 1rem 0; }
+      .markdown-body hr { border: 0; border-top: 1px solid #e5e5e5; margin: 1.5rem 0; }
+    </style>
     <!--
       If using a TypeScript entrypoint file:
         vite_typescript_tag 'application'
@@ -38,7 +57,25 @@
 
   </head>
 
-  <body class="ms:dark:bg-neutral-900 ms:dark:text-neutral-50">
-    <%= yield %>
+  <body class="ms:dark:bg-neutral-900 ms:dark:text-neutral-50 bg-neutral-50 text-neutral-900 antialiased">
+    <header class="border-b border-neutral-200 bg-white">
+      <div class="max-w-3xl mx-auto px-6 py-5 flex items-center justify-between">
+        <%= link_to "Marksmith Blog", root_path, class: "text-lg font-semibold text-neutral-900 hover:text-neutral-700" %>
+        <nav class="flex items-center gap-4 text-sm">
+          <%= link_to "All posts", posts_path, class: "text-neutral-600 hover:text-neutral-900" %>
+          <%= link_to "New post", new_post_path, class: "inline-flex items-center rounded-md bg-neutral-900 px-3 py-1.5 text-white hover:bg-neutral-800" %>
+        </nav>
+      </div>
+    </header>
+
+    <main class="max-w-3xl mx-auto px-6 py-10">
+      <% if notice.present? %>
+        <div class="mb-6 rounded-md border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-800">
+          <%= notice %>
+        </div>
+      <% end %>
+
+      <%= yield %>
+    </main>
   </body>
 </html>

--- a/test/dummy/app/views/posts/_form.html.erb
+++ b/test/dummy/app/views/posts/_form.html.erb
@@ -1,9 +1,15 @@
-<%= form_with(model: post) do |form| %>
-  <% if post.errors.any? %>
-    <div style="color: red">
-      <h2><%= pluralize(post.errors.count, "error") %> prohibited this post from being saved:</h2>
+<%= form_with(model: post, class: "space-y-6 rounded-lg border border-neutral-200 bg-white p-6 shadow-sm") do |form| %>
+  <div class="flex items-center justify-end gap-3">
+    <%= link_to "Cancel", (post.persisted? ? post : posts_path), class: "text-sm text-neutral-600 hover:text-neutral-900" %>
+    <%= form.submit class: "inline-flex items-center rounded-md bg-neutral-900 px-4 py-2 text-sm font-medium text-white hover:bg-neutral-800 cursor-pointer" %>
+  </div>
 
-      <ul>
+  <% if post.errors.any? %>
+    <div class="rounded-md border border-red-200 bg-red-50 p-4">
+      <h2 class="text-sm font-semibold text-red-800">
+        <%= pluralize(post.errors.count, "error") %> prohibited this post from being saved:
+      </h2>
+      <ul class="mt-2 list-disc pl-5 text-sm text-red-700">
         <% post.errors.each do |error| %>
           <li><%= error.full_message %></li>
         <% end %>
@@ -12,20 +18,12 @@
   <% end %>
 
   <div>
-    <%= form.label :title, style: "display: block" %>
-    <%= form.text_field :title %>
-  </div>
-
-  <div class="w-full">
-    <%= form.label :body, style: "display: block" %>
-    <div style="width: 650px; resize: both; overflow: auto; padding: 10px;">
-      <%#= form.marksmith :body, disabled: false, style: "border: 1px solid red;", placeholder: "Enter your markdown body here" %>
-      <%= form.marksmith :body, enable_file_uploads: true, upload_url: nil %>
-    </div>
-
+    <%= form.label :title, class: "block text-sm font-medium text-neutral-700" %>
+    <%= form.text_field :title, class: "mt-1 block w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-neutral-900 shadow-sm focus:border-neutral-500 focus:outline-none focus:ring-1 focus:ring-neutral-500" %>
   </div>
 
   <div>
-    <%= form.submit %>
+    <%= form.label :body, class: "block text-sm font-medium text-neutral-700 mb-1" %>
+    <%= form.marksmith :body, enable_file_uploads: true, upload_url: nil %>
   </div>
 <% end %>

--- a/test/dummy/app/views/posts/_post.html.erb
+++ b/test/dummy/app/views/posts/_post.html.erb
@@ -1,12 +1,9 @@
-<div id="<%= dom_id post %>">
-  <p>
-    <strong>Title:</strong>
-    <%= post.title %>
-  </p>
+<article id="<%= dom_id post %>" class="rounded-lg border border-neutral-200 bg-white p-8 shadow-sm">
+  <h1 class="text-3xl font-bold tracking-tight text-neutral-900">
+    <%= post.title.presence || "Untitled" %>
+  </h1>
 
-  <p>
-    <strong>Body:</strong>
+  <div class="markdown-body mt-6 leading-relaxed text-neutral-800">
     <%== marksmithed(post.body) %>
-  </p>
-
-</div>
+  </div>
+</article>

--- a/test/dummy/app/views/posts/edit.html.erb
+++ b/test/dummy/app/views/posts/edit.html.erb
@@ -1,12 +1,14 @@
-<% content_for :title, "Editing post" %>
+<% content_for :title, "Editing #{@post.title}" %>
 
-<h1>Editing post</h1>
+<div class="mb-6">
+  <h1 class="text-3xl font-bold tracking-tight text-neutral-900">Editing post</h1>
+  <p class="mt-1 text-sm text-neutral-500">Update the title or body and save your changes.</p>
+</div>
 
 <%= render "form", post: @post %>
 
-<br>
-
-<div>
-  <%= link_to "Show this post", @post %> |
-  <%= link_to "Back to posts", posts_path %>
+<div class="mt-6 flex items-center gap-4 text-sm">
+  <%= link_to "View this post", @post, class: "text-neutral-700 hover:text-neutral-900 hover:underline" %>
+  <span class="text-neutral-300">·</span>
+  <%= link_to "Back to posts", posts_path, class: "text-neutral-600 hover:text-neutral-900" %>
 </div>

--- a/test/dummy/app/views/posts/index.html.erb
+++ b/test/dummy/app/views/posts/index.html.erb
@@ -1,16 +1,37 @@
-<p style="color: green"><%= notice %></p>
-
 <% content_for :title, "Posts" %>
 
-<h1>Posts</h1>
-
-<div id="posts">
-  <% @posts.each do |post| %>
-    <%= render post %>
-    <p>
-      <%= link_to "Show this post", post %>
-    </p>
-  <% end %>
+<div class="mb-8 flex items-end justify-between">
+  <div>
+    <h1 class="text-3xl font-bold tracking-tight text-neutral-900">Posts</h1>
+    <p class="mt-1 text-sm text-neutral-500"><%= pluralize(@posts.size, "post") %> published</p>
+  </div>
 </div>
 
-<%= link_to "New post", new_post_path %>
+<% if @posts.any? %>
+  <div id="posts" class="space-y-4">
+    <% @posts.each do |post| %>
+      <article id="<%= dom_id post %>" class="rounded-lg border border-neutral-200 bg-white p-6 shadow-sm hover:border-neutral-300">
+        <h2 class="text-xl font-semibold text-neutral-900">
+          <%= link_to post.title.presence || "Untitled", post, class: "hover:underline" %>
+        </h2>
+
+        <% if post.body.present? %>
+          <p class="mt-2 line-clamp-3 text-sm text-neutral-600">
+            <%= truncate(post.body.to_s.gsub(/[#*_`>\-]/, " ").squish, length: 200) %>
+          </p>
+        <% end %>
+
+        <div class="mt-4 flex items-center gap-3 text-sm">
+          <%= link_to "View", post, class: "font-medium text-neutral-900 hover:underline" %>
+          <span class="text-neutral-300">·</span>
+          <%= link_to "Edit", edit_post_path(post), class: "text-neutral-600 hover:text-neutral-900" %>
+        </div>
+      </article>
+    <% end %>
+  </div>
+<% else %>
+  <div class="rounded-lg border border-dashed border-neutral-300 bg-white p-12 text-center">
+    <p class="text-neutral-600">No posts yet.</p>
+    <%= link_to "Write the first post", new_post_path, class: "mt-3 inline-flex items-center rounded-md bg-neutral-900 px-3 py-1.5 text-sm text-white hover:bg-neutral-800" %>
+  </div>
+<% end %>

--- a/test/dummy/app/views/posts/new.html.erb
+++ b/test/dummy/app/views/posts/new.html.erb
@@ -1,11 +1,12 @@
 <% content_for :title, "New post" %>
 
-<h1>New post</h1>
+<div class="mb-6">
+  <h1 class="text-3xl font-bold tracking-tight text-neutral-900">New post</h1>
+  <p class="mt-1 text-sm text-neutral-500">Write something with Markdown.</p>
+</div>
 
 <%= render "form", post: @post %>
 
-<br>
-
-<div>
-  <%= link_to "Back to posts", posts_path %>
+<div class="mt-6">
+  <%= link_to "← Back to posts", posts_path, class: "text-sm text-neutral-600 hover:text-neutral-900" %>
 </div>

--- a/test/dummy/app/views/posts/show.html.erb
+++ b/test/dummy/app/views/posts/show.html.erb
@@ -1,10 +1,12 @@
-<p style="color: green"><%= notice %></p>
+<% content_for :title, @post.title %>
+
+<div class="mb-6 flex items-center justify-between">
+  <%= link_to "← Back to posts", posts_path, class: "text-sm text-neutral-600 hover:text-neutral-900" %>
+
+  <div class="flex items-center gap-3">
+    <%= link_to "Edit", edit_post_path(@post), class: "inline-flex items-center rounded-md border border-neutral-300 bg-white px-3 py-1.5 text-sm font-medium text-neutral-700 hover:bg-neutral-50" %>
+    <%= button_to "Delete", @post, method: :delete, form: { data: { turbo_confirm: "Are you sure?" } }, class: "inline-flex items-center rounded-md border border-red-200 bg-white px-3 py-1.5 text-sm font-medium text-red-600 hover:bg-red-50 cursor-pointer" %>
+  </div>
+</div>
 
 <%= render @post %>
-
-<div>
-  <%= link_to "Edit this post", edit_post_path(@post) %> |
-  <%= link_to "Back to posts", posts_path %>
-
-  <%= button_to "Destroy this post", @post, method: :delete %>
-</div>


### PR DESCRIPTION
wonky tab border and dummy tweaks


https://github.com/user-attachments/assets/ca4506d2-6d9e-4b84-8425-332305f76323



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CSS class tweaks and dummy-app view/layout updates, with no backend logic or data-handling changes.
> 
> **Overview**
> Fixes the Marksmith editor’s *wonky tab border* styling by adjusting tab spacing/height classes and ensuring the active tab has a transparent bottom border, and removes rounding on the editor textarea to better align with surrounding chrome.
> 
> Updates the `test/dummy` blog UI with a new Tailwind-powered layout (header/nav, notice styling, base body classes) plus inline `.markdown-body` styling, and restyles posts index/show/new/edit/form views for a more polished presentation (including preview snippets and improved actions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ab2c2c874dd5f8f6376fd1f4986075bfb70b669. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->