### PR TITLE
Avo field: collapsable show view and always_show option

### DIFF
--- a/app/components/marksmith/markdown_field/show_component.html.erb
+++ b/app/components/marksmith/markdown_field/show_component.html.erb
@@ -1,3 +1,3 @@
-<%= field_wrapper **field_wrapper_args, full_width: true do %>
+<%= field_wrapper **field_wrapper_args, full_width: true, collapsable: !@field.always_show do %>
   <%= render partial: "marksmith/shared/rendered_body", locals: { body: Marksmith::Renderer.new(body: @field.value).render } %>
 <% end %>

--- a/lib/marksmith/fields/markdown_field.rb
+++ b/lib/marksmith/fields/markdown_field.rb
@@ -1,6 +1,9 @@
 module Marksmith
   module Fields
     class MarkdownField < Avo::Fields::BaseField
+      # Avo >= 4.2 lets the editor viewport be resized with a persisted height.
+      resizable_editor target: ".marksmith-textarea" if respond_to?(:resizable_editor)
+
       attr_reader :extra_preview_params,
         :file_uploads,
         :always_show

--- a/lib/marksmith/fields/markdown_field.rb
+++ b/lib/marksmith/fields/markdown_field.rb
@@ -2,12 +2,14 @@ module Marksmith
   module Fields
     class MarkdownField < Avo::Fields::BaseField
       attr_reader :extra_preview_params,
-        :file_uploads
+        :file_uploads,
+        :always_show
 
       def initialize(id, **args, &block)
         @media_library = args[:media_library].nil? ? true : args[:media_library]
         @extra_preview_params = args[:extra_preview_params] || {}
         @file_uploads = args[:file_uploads]
+        @always_show = args[:always_show] || false
 
         super(id, **args, &block)
 


### PR DESCRIPTION
## What

- The Avo show view now renders through the field wrapper's new `collapsable` option (collapsed faded preview + animated More/Less content toggle), matching the rest of Avo's WYSIWYG fields (trix, rhino, lexxy, easy_mde, tiptap, code).
- Adds `always_show` (default `false`) to skip the collapsed preview and render the full content.

## Depends on

- avo-hq/avo PR adding `Avo::Fields::Common::CollapsableContentComponent` and the field wrapper `collapsable` option (same batch as this PR). Only affects the Avo integration; standalone marksmith usage is untouched.

## Tested

- `spec/system/avo/group_1/wysiwyg_more_less_content_spec.rb` in the avo repo covers the marksmith field's collapse/expand behavior alongside the other editors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Show-view presentation and an optional Avo editor UX hook only; no auth, data, or rendering pipeline changes beyond how content is displayed on show.
> 
> **Overview**
> **Avo show integration** for `MarkdownField` now passes **`collapsable: !@field.always_show`** into the field wrapper so long rendered markdown matches other Avo WYSIWYG fields (faded preview + More/Less), unless the field opts out.
> 
> Adds field option **`always_show`** (default **`false`**) on `Marksmith::Fields::MarkdownField`, wired through the show component. When **`true`**, the wrapper is not collapsible and the full rendered body shows immediately.
> 
> Also registers **`resizable_editor`** on **`.marksmith-textarea`** when Avo supports it (≥ 4.2), so edit view height can be persisted like other editors.
> 
> **Depends on** upstream Avo support for the field wrapper **`collapsable`** option and `CollapsableContentComponent`; standalone Marksmith is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37ea54d04e91126e0e49cd48023b51c74dd3dab4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->